### PR TITLE
Add missing `Suggests` entries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,6 +47,8 @@ Imports: GenomicRanges,
   splines
 Suggests: knitr, 
   rmarkdown, 
+  TxDb.Hsapiens.UCSC.hg19.knownGene,
+  org.Hs.eg.db,
   BiocStyle
 biocViews: ImmunoOncology, DNAMethylation, Epigenetics, MultipleComparison, Software,
   Sequencing, DifferentialMethylation, WholeGenome, Regression, 


### PR DESCRIPTION
It seems `TxDb.Hsapiens.UCSC.hg19.knownGene` and `org.Hs.eg.db` are transitive dependencies that must be explicitly declared for Bioc 3.18, because of _R_CHECK_SUGGESTS_ONLY_=true

See https://support.bioconductor.org/p/9153573/#9153581 for more details.

Without these additions the `R CMD check` [fails](https://bioconductor.org/checkResults/3.18/bioc-LATEST/dmrseq/nebbiolo2-checksrc.html) with:

```
Error in get(txdb_name) : 
  object 'TxDb.Hsapiens.UCSC.hg19.knownGene' not found

Trying again (4 attempts remaining)
Error in get(txdb_name) : 
  object 'TxDb.Hsapiens.UCSC.hg19.knownGene' not found

Trying again (3 attempts remaining)
Error in get(txdb_name) : 
  object 'TxDb.Hsapiens.UCSC.hg19.knownGene' not found

Trying again (2 attempts remaining)
Error in get(txdb_name) : 
  object 'TxDb.Hsapiens.UCSC.hg19.knownGene' not found

Trying again (1 attempts remaining)
Error in get(txdb_name) : 
  object 'TxDb.Hsapiens.UCSC.hg19.knownGene' not found

Error in getAnnot("hg19") : Annotation could not be retrieved.
Execution halted
* checking for unstated dependencies in vignettes ... OK
* checking package vignettes in ‘inst/doc’ ... OK
* checking running R code from vignettes ...
  ‘dmrseq.Rmd’... OK
 NONE
* checking re-building of vignette outputs ... ERROR
Error(s) in re-building vignettes:
  ...
```